### PR TITLE
Extract pypi_helper.py from setup.py

### DIFF
--- a/pypi_helper.py
+++ b/pypi_helper.py
@@ -1,0 +1,74 @@
+# Copied from https://github.com/GiraffeReversed/edulint-web/blob/main/setup.py
+
+import requests
+from typing import Dict, Any, List, Optional
+from collections import defaultdict
+import argparse
+
+from utils import Version
+
+
+def _fully_released_versions(data: Dict[str, Any]) -> List[Version]:
+    releases = data["releases"]
+
+    version_ids = [v for v in releases.keys()]
+    valid_versions: List[Version] = []
+
+    for version_id in version_ids:
+        has_some_builds: bool = bool(len(releases[version_id]))
+        is_yanked: bool = any([x.get('yanked') for x in releases[version_id]])
+        version_parsed: Optional[Version] = Version.parse(version_id)
+
+        if has_some_builds and not is_yanked and version_parsed:
+            valid_versions.append(version_parsed)
+    
+    return valid_versions
+
+
+def _only_last_patch_of_each_minor(versions: List[Version]) -> List[Version]:
+    major_minor: Dict[str, Version] = defaultdict(list)
+    for version in versions:
+        major_minor[f"{version.major}.{version.minor}"].append(version)
+    for key in major_minor:
+        major_minor[key].sort(reverse=True)
+    patches_only = [major_minor[key][0] for key in major_minor]
+    sorted_patches = list(sorted(patches_only, key = lambda x: (x.major, x.minor)))
+    return sorted_patches
+
+
+def get_versions(package_name: str = 'edulint') -> List[Version]:
+    edulint_info = requests.get(f"https://pypi.org/pypi/{package_name}/json").json()
+    version_ids: List[Version] = _fully_released_versions(edulint_info)
+    return version_ids
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('package_name')
+    parser.add_argument('-g', '--github', default=False, action='store_true')
+    parser.add_argument('-n', '--n-versions', type=int, default=5)
+    args = parser.parse_args()
+   
+
+    package_name: str = args.package_name
+    github_output: bool = args.github
+    number_of_versions: int = args.n_versions
+
+    versions = get_versions(package_name)
+    versions = _only_last_patch_of_each_minor(versions)
+    versions_str = [str(x) for x in versions]
+    choosen_versions = versions_str[-number_of_versions:]
+    
+    if github_output:
+        versions_as_str = str(choosen_versions).replace("'", "\"")
+        # answer = f'{package_name}=\'{versions_as_str}\''
+        
+        # https://github.com/actions/runner/issues/1660#issuecomment-1359707506
+        answer = f"""{package_name}<<EOF
+{versions_as_str}
+EOF"""
+    else:
+        answer = str(choosen_versions)
+    
+    print(answer)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from typing import Dict, Any, List, Optional
 from collections import defaultdict
 
 from utils import Version
-
+from pypi_helper import get_versions
 
 CONFIG = {
     "CODE_FOLDER": "codes",
@@ -16,42 +16,7 @@ CONFIG = {
     "LINTER_FOLDER_PREFIX": "edulint",
     "EXPLANATIONS": "explanations.json",
 }
-
-
-def _fully_released_versions(data: Dict[str, Any]) -> List[Version]:
-    releases = data["releases"]
-
-    version_ids = [v for v in releases.keys()]
-    valid_versions: List[Version] = []
-
-    for version_id in version_ids:
-        has_some_builds: bool = bool(len(releases[version_id]))
-        is_yanked: bool = any([x.get('yanked') for x in releases[version_id]])
-        version_parsed: Optional[Version] = Version.parse(version_id)
-
-        if has_some_builds and not is_yanked and version_parsed:
-            valid_versions.append(version_parsed)
-
-    return valid_versions
-
-
-def _only_last_patch_of_each_minor(versions: List[Version]) -> List[Version]:
-    major_minor: Dict[str, Version] = defaultdict(list)
-    for version in versions:
-        major_minor[f"{version.major}.{version.minor}"].append(version)
-    for key in major_minor:
-        major_minor[key].sort(reverse=True)
-    return [major_minor[key][0] for key in major_minor]
-
-
-def get_versions() -> List[Version]:
-    edulint_info = requests.get("https://pypi.org/pypi/edulint/json").json()
-    version_ids: List[Version] = _fully_released_versions(edulint_info)
-    version_ids = _only_last_patch_of_each_minor(version_ids)
-    version_ids = [v_id for v_id in version_ids if v_id.major >= 3 or (v_id.major == 2 and v_id.minor >= 7)]
-
-    return version_ids
-
+ 
 
 def prepare_config(config, versions):
     config = config.copy()
@@ -68,7 +33,8 @@ def prepare_packages(config, versions):
 
 
 if __name__ == "__main__":
-    versions = get_versions()
+    versions = get_versions('edulint')
+    versions = [v_id for v_id in versions if v_id.major >= 2]
 
     prepare_packages(CONFIG, versions)
     prepare_config(CONFIG, versions)


### PR DESCRIPTION
Edulint newly started querying pypi not just for edulint-web package build, but also for [edulint compatibility tests](https://github.com/GiraffeReversed/edulint/blob/8f4568e06209ec146cd8a507a8f67d17922819f6/.github/workflows/test-compatibility.yaml#L29).
Both edulint and edulint-web require the same bit of code. For ease of use I've extracted it from setup.py to a separate file `pypi_helper.py`.