### PR TITLE
Fix Flask compatibility, Add canonical link

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
 /codes/
 /uploaded_files/
+/.git/
+/__pycache__/
+/logs/
+

--- a/app.py
+++ b/app.py
@@ -49,8 +49,7 @@ def get_explanations():
     return get_explanations()
 
 
-@app.before_first_request
-def prepare_HTML_explanations():
+def prepare_HTML_explanations(app):
     exps = with_version(get_latest(app.config["VERSIONS"]), get_explanations)
 
     HTML_exps = {
@@ -62,6 +61,9 @@ def prepare_HTML_explanations():
 
     with open(explanations_path(app.config), "w") as f:
         f.write(json.dumps(HTML_exps))
+
+with app.app_context():
+    prepare_HTML_explanations(app)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask>=2.0.3,<2.3.0  # 2.3.0 removes before_first_request
+flask>=2.0.3
 flask-talisman
 flask-caching
 flask-cors

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask>=2.0.3
+flask>=2.0.3,<2.3.0  # 2.3.0 removes before_first_request
 flask-talisman
 flask-caching
 flask-cors

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,6 +18,8 @@
   <script src="/static/base.js"></script>
   <script src="/static/plaus-dynamic-domain.js"></script>
   
+  <link rel="canonical" href="https://edulint.com{{ url_for(request.endpoint, **request.view_args) }}" />
+
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='code_highlighting.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='code_highlighting_dark.css') }}">


### PR DESCRIPTION
- Flask >= 2.3.0 no longer has `@app.before_first_request`, which was blocking the web server start. Fixed.
- Added canonical URL always pointing to https://edulint.com/<PATH>
- Extended .dockerignore for quicker Docker build.

---

Outside of this PR I've deployed on Cloudflare redirect rules for
- `www.edulint.com` -> `edulint.com`
- `edulint.rechtackova.cz` -> `edulint.com`

The redirects preserve path and query. It is also only applied to GET requests, so old URLs for POSTs will still work.

---

Deployed to [dev server](https://dev.edulint.com) and quickly tested.